### PR TITLE
Add "Authorization" to Allow Headers

### DIFF
--- a/bases/rest-api/src/clojure/realworld/rest_api/middleware.clj
+++ b/bases/rest-api/src/clojure/realworld/rest_api/middleware.clj
@@ -36,11 +36,10 @@
   (let [allowed-origins (env :allowed-origins)
         origins        (str/split allowed-origins #",")
         allowed-origin (some #{origin} origins)]
-    {"Access-Control-Allow-Origin"      allowed-origin
-     "Access-Control-Allow-Methods"     "POST, GET, PUT, OPTIONS, DELETE"
-     "Access-Control-Max-Age"           "3600"
-     "Access-Control-Allow-Headers"     "Authorization, Content-Type, x-requested-with"
-     "Access-Control-Allow-Credentials" "true"}))
+    {"Access-Control-Allow-Origin"  allowed-origin
+     "Access-Control-Allow-Methods" "POST, GET, PUT, OPTIONS, DELETE"
+     "Access-Control-Max-Age"       "3600"
+     "Access-Control-Allow-Headers" "Authorization, Content-Type, x-requested-with"}))
 
 (defn wrap-cors [handler]
   (fn [req]

--- a/bases/rest-api/src/clojure/realworld/rest_api/middleware.clj
+++ b/bases/rest-api/src/clojure/realworld/rest_api/middleware.clj
@@ -39,7 +39,7 @@
     {"Access-Control-Allow-Origin"      allowed-origin
      "Access-Control-Allow-Methods"     "POST, GET, PUT, OPTIONS, DELETE"
      "Access-Control-Max-Age"           "3600"
-     "Access-Control-Allow-Headers"     "Content-Type, x-requested-with"
+     "Access-Control-Allow-Headers"     "Authorization, Content-Type, x-requested-with"
      "Access-Control-Allow-Credentials" "true"}))
 
 (defn wrap-cors [handler]


### PR DESCRIPTION
All auth routes won't work without it. When we make a request to an auth route the `authorization` header is requested:
```Access-Control-Request-Headers: authorization,content-type```

So, backend has to allow it as well.