### PR TITLE
Add ability to update article tags

### DIFF
--- a/components/article/src/clojure/realworld/article/spec.clj
+++ b/components/article/src/clojure/realworld/article/spec.clj
@@ -14,7 +14,8 @@
   (ds/spec {:name :core/update-article
             :spec {(ds/opt :title)       spec/non-empty-string?
                    (ds/opt :description) spec/non-empty-string?
-                   (ds/opt :body)        spec/non-empty-string?}}))
+                   (ds/opt :body)        spec/non-empty-string?
+                   (ds/opt :tagList)     [spec/non-empty-string?]}}))
 
 (def article
   (ds/spec {:name :core/article

--- a/components/article/test/clojure/realworld/article/store_test.clj
+++ b/components/article/test/clojure/realworld/article/store_test.clj
@@ -78,6 +78,27 @@
         res (store/article-tags 1)]
     (is (= ["tag1" "tag2" "tag3"] res))))
 
+(deftest update-article-tags!--add-new-tags
+  (let [_   (jdbc/insert-multi! (test-db) :tag [{:name "tag1"}
+                                                {:name "tag2"}
+                                                {:name "tag3"}
+                                                {:name "tag4"}
+                                                {:name "tag5"}
+                                                {:name "tag6"}])
+        _   (store/add-tags-to-article! 1 ["tag1" "tag2" "tag3"])
+        _   (store/update-article-tags! 1 ["tag4" "tag5" "tag6"])
+        res (store/article-tags 1)]
+    (is (= ["tag4" "tag5" "tag6"] res))))
+
+(deftest update-article-tags!--delete-all-tags
+  (let [_   (jdbc/insert-multi! (test-db) :tag [{:name "tag1"}
+                                                {:name "tag2"}
+                                                {:name "tag3"}])
+        _   (store/add-tags-to-article! 1 ["tag1" "tag2" "tag3"])
+        _   (store/update-article-tags! 1 [])
+        res (store/article-tags 1)]
+    (is (empty? res))))
+
 (deftest article-tags--test
   (let [_   (jdbc/insert-multi! (test-db) :tag [{:name "tag1"}
                                                 {:name "tag2"}


### PR DESCRIPTION
Although it's out of the [spec](https://github.com/gothinkster/realworld/tree/master/api#update-article), I believe it makes sense to add. Especially that the [official demo](https://demo.realworld.io) allows you to update article tags.