### PR TITLE
Change param-reading function to safer one

### DIFF
--- a/bases/rest-api/src/clojure/realworld/rest_api/handler.clj
+++ b/bases/rest-api/src/clojure/realworld/rest_api/handler.clj
@@ -11,7 +11,7 @@
 (defn- parse-query-param [param]
   (if (string? param)
     (try
-      (read-string param)
+      (clojure.edn/read-string param)
       (catch Exception _
         param))
     param))


### PR DESCRIPTION
I guess it's way safer to use `clojure.edn/read-string` when getting user input here

