### PR TITLE
Make build script portable

### DIFF
--- a/systems/realworld-backend/build.sh
+++ b/systems/realworld-backend/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 lein ring uberwar realworld-backend.war


### PR DESCRIPTION
I tried running `lein polylith build` but it failed. I'm using [NixOS](https://nixos.org/) as my linux distribution, and it isn't FHS compliant so hardcoded calls to `/bin/bash` fail. This should fix that.