### PR TITLE
REPL get started focus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,9 @@
 database.db
 test.db
 *.iml
+
+# clojure-lsp
+.lsp/sqlite*.db
+
+# Calva VS Code extension
+.calva/output-window/output.calva-repl

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,14 @@
+{
+    "calva.autoOpenJackInTerminal": true,
+    "calva.replConnectSequences": [
+        {
+            "projectType": "deps.edn",
+            "afterCLJReplJackInCode": "(do (require '[dev.server] :reload) (in-ns 'dev.server))\n;Once the REPL is active, (start!) will start the server",
+            "name": "Polylith RealWorld Server REPL",
+            "cljsType": "none",
+            "menuSelections": {
+                "cljAliases": ["dev", "test"]
+            }
+        }
+    ]
+}

--- a/bases/rest-api/src/clojure/realworld/rest_api/main.clj
+++ b/bases/rest-api/src/clojure/realworld/rest_api/main.clj
@@ -1,8 +1,32 @@
 (ns clojure.realworld.rest-api.main
   (:require [clojure.realworld.rest-api.api :as api]
+            [clojure.realworld.log.interface :as log]
             [ring.adapter.jetty :refer [run-jetty]])
   (:gen-class))
 
-(defn -main [& args]
-  (api/init)
-  (run-jetty api/app {:port (Integer/valueOf (or (System/getenv "port") "6003") 10)}))
+(def ^:private server-ref (atom nil))
+
+(defn start!
+  [port]
+  (if-let [_server @server-ref]
+    (log/warn "Server already running? (stop!) it first.")
+    (do
+      (log/info "Starting server on port: " port)
+      (api/init)
+      (reset! server-ref
+              (run-jetty api/app
+                         {:port port
+                          :join? false})))))
+
+(defn stop! []
+  (if-let [server @server-ref]
+    (do (api/destroy)
+        (.stop server)
+        (reset! server-ref nil))
+    (log/warn "No server")))
+
+(defn -main [& _args]
+  (start! (Integer/valueOf
+           (or (System/getenv "port")
+               "6003")
+           10)))

--- a/bases/rest-api/src/clojure/realworld/rest_api/main.clj
+++ b/bases/rest-api/src/clojure/realworld/rest_api/main.clj
@@ -1,6 +1,6 @@
 (ns clojure.realworld.rest-api.main
-  (:require [clojure.realworld.rest-api.api :as api]
-            [clojure.realworld.log.interface :as log]
+  (:require [clojure.realworld.log.interface :as log]
+            [clojure.realworld.rest-api.api :as api]
             [ring.adapter.jetty :refer [run-jetty]])
   (:gen-class))
 

--- a/development/src/dev/server.clj
+++ b/development/src/dev/server.clj
@@ -1,0 +1,12 @@
+(ns dev.server
+  (:require [clojure.realworld.rest-api.main :as main]))
+
+(defn start! [port]
+  (main/start! port))
+
+(defn stop! []
+  (main/stop!))
+
+(comment
+  (start! 6003)
+  (stop!))

--- a/env.edn
+++ b/env.edn
@@ -1,2 +1,3 @@
-{:environment "LOCAL"
+{:allowed-origins "http://localhost:3000,http://localhost:4100"
+ :environment "LOCAL"
  :database    "database.db"}

--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@ A full-fledged [RealWorld](https://github.com/gothinkster/realworld) server (CRU
 ## Start it in your Clojure REPL
 
 1. Fork & clone this repo
-1. Open the project in your favorite Clojure editor, start the project, and connect the REPL. (From a development perspective it is a regular `deps.edn` project.)
+1. Open the project in your favorite Clojure editor, start the project, and connect the REPL. From a development perspective it is a regular `deps.edn` project. Just make sure to include the `:dev` and `:test` aliases, and you should be good.
 1. In the `dev.server` namespace, evaluate:
     ```clojure
     (start! 6003)

--- a/readme.md
+++ b/readme.md
@@ -45,7 +45,7 @@ Then start the frontend and open http://localhost:3000/ in a web browser.
 - [Environment Variables](#environment-variables)
 - [Database](#database)
 - [Workspace Info](#workspace-info)
-- [Check Workspace Integrity](#workspace-info)
+- [Check Workspace Integrity](#check-workspace-integrity)
 - [Running Tests](#running-tests)
 - [Stable Points](#stable-points)
 - [Continuous Integration](#continuous-integration)

--- a/readme.md
+++ b/readme.md
@@ -1,25 +1,42 @@
 # ![RealWorld Example App](logo.png)
 
-> ### Clojure, Polylith and Ring codebase containing real world examples (CRUD, auth, advanced patterns, etc) that adheres to the [RealWorld](https://github.com/gothinkster/realworld-example-apps) spec and API.
-
-
-### [RealWorld](https://github.com/gothinkster/realworld)
-
-
-This codebase was created to demonstrate a fully fledged fullstack application built with **Clojure, Polylith and Ring** including CRUD operations, authentication, routing, pagination, and more.
-
-We've gone to great lengths to adhere to the **Clojure** community styleguides & best practices.
-
-For more information on how this works with other frontends/backends, head over to the [RealWorld](https://github.com/gothinkster/realworld) repo.
-
-> This version uses [tools.deps](https://github.com/clojure/tools.deps.alpha). There is also an older version of this project that uses [Leiningen](https://leiningen.org/) on the [leiningen branch](https://github.com/furkan3ayraktar/clojure-polylith-realworld-example-app/tree/leiningen).
+A full-fledged [RealWorld](https://github.com/gothinkster/realworld) server (CRUD, auth, advanced patterns, etc) built with [Clojure](https://clojure.org), [Polylith](https://polylith.gitbook.io/), and [Ring](https://github.com/ring-clojure/ring), including CRUD operations, authentication, routing, pagination, and more.
 
 #### Build Status
 [![CircleCI](https://circleci.com/gh/furkan3ayraktar/clojure-polylith-realworld-example-app/tree/master.svg?style=svg&circle-token=927fe6a1ea0db6ea74775199135b5feb92292818)](https://circleci.com/gh/furkan3ayraktar/clojure-polylith-realworld-example-app/tree/master)
 
+## Start it in your Clojure REPL
+
+1. Fork & clone this repo
+1. Open the project in your favorite Clojure editor, start the project, and connect the REPL. (From a development perspective it is a regular `deps.edn` project.)
+1. In the `dev.server` namespace, evaluate:
+    ```clojure
+    (start! 6003)
+    ```
+
+Now the Polylith RealWorld backend is up on port 6003!
+
+### Test it with a RealWorld Frontend
+
+A sweet way to put the sever to some tests is to fork the [re-frame RealWorld frontend by Jacek Schae](https://github.com/jacekschae/conduit) and modify it to run against this server by editing the definition of `api-url` in `src/conduit/events.cljs` to be:
+
+```clojure
+(def api-url "http://localhost:6003/api")
+```
+
+Then start the frontend and open http://localhost:3000/ in a web browser.
+
+## Put the `poly` command to your service
+
+1. Install the [Polylith tool](https://github.com/polyfy/polylith#installation)
+2. Get ”at a glance" info about the project:
+    ```sh
+    $ poly info
+    ```   
+
 ## Table of Contents
 
-- [Getting Started](#getting-started)
+- [Getting Started](#start-it-in-your-clojure-repl)
 - [General Structure](#general-structure)
   - [Project](#project)
   - [Base](#base)
@@ -33,15 +50,6 @@ For more information on how this works with other frontends/backends, head over 
 - [Continuous Integration](#continuous-integration)
 - [How to create this workspace from scratch](#how-to-create-this-workspace-from-scratch)
 
-### Getting started
-
-Just a few steps to have you up and running locally:
-
-+ Install the [Polylith tool](https://github.com/polyfy/polylith#installation)
-+ Clone this repo
-+ Open a terminal, navigate to the root directory of this repo and run ``clj -A:ring realworld-backend``
-
-and the Realworld backend is up on port 6003!
 
 ### General Structure
 This project is structured according to Polylith Architecture principles. 
@@ -394,3 +402,7 @@ You can achieve the same result with fewer steps once you have learned the comma
 
 ### How to create this workspace from scratch
 You can find necessary steps to create this workspace with Polylith plugin [here](how-to.md).
+
+### Note about deps.edn vs Leiningen
+
+> This version uses [tools.deps](https://github.com/clojure/tools.deps.alpha). There is also an older version of this project that uses [Leiningen](https://leiningen.org/) on the [leiningen branch](https://github.com/furkan3ayraktar/clojure-polylith-realworld-example-app/tree/leiningen).

--- a/readme.md
+++ b/readme.md
@@ -33,6 +33,7 @@ Then start the frontend and open http://localhost:3000/ in a web browser.
     ```sh
     $ poly info
     ```   
+(See [Workspace Info](#workspace-info) below.)
 
 ## Table of Contents
 


### PR DESCRIPTION
- Starting the server from the REPL no longer blocks the REPL.
- api/main has commands for starting and stopping the server
- There is a `dev.server` namespace for staring and stopping the server from the REPL
- There is a Calva REPL start config that makes starting the server from a Calva REPL easy
- The README goes straight at starting the server from the REPL