### PR TITLE
Remove `exit` after opening the getting_started.clj file

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -18,6 +18,6 @@ tasks:
   - name: Polylith Real World nREPL Server
     command: clojure -Sdeps '{:deps {nrepl/nrepl {:mvn/version,"1.0.0"},cider/cider-nrepl {:mvn/version,"0.28.5"}}}' -M:dev:test:default -m nrepl.cmdline --middleware "[cider.nrepl/cider-middleware]"
   - name: Open Getting Started
-    command: code development/src/dev/getting_started.clj ; sleep 3; exit
+    command: code development/src/dev/getting_started.clj
   - name: Poly Tool
     command: poly

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -18,6 +18,6 @@ tasks:
   - name: Polylith Real World nREPL Server
     command: clojure -Sdeps '{:deps {nrepl/nrepl {:mvn/version,"1.0.0"},cider/cider-nrepl {:mvn/version,"0.28.5"}}}' -M:dev:test:default -m nrepl.cmdline --middleware "[cider.nrepl/cider-middleware]"
   - name: Open Getting Started
-    command: code development/src/dev/getting_started.clj ; exit
+    command: code development/src/dev/getting_started.clj ; sleep 3; exit
   - name: Poly Tool
     command: poly


### PR DESCRIPTION
Now when I tested the gitpodified project, it didn't open the getting_started.clj file. Or, I realized it probably does that and then closes it, or something. Could be a race condition. I removed the `; exit` from the config which opens the file. It was to close the terminal that was used for the task, because noisy. But it's better the file stays open!