### PR TITLE
Poly clarity

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -19,5 +19,5 @@ tasks:
     command: clojure -Sdeps '{:deps {nrepl/nrepl {:mvn/version,"1.0.0"},cider/cider-nrepl {:mvn/version,"0.28.5"}}}' -M:dev:test:default -m nrepl.cmdline --middleware "[cider.nrepl/cider-middleware]"
   - name: Open Getting Started
     command: code development/src/dev/getting_started.clj
-  - name: Poly Tool
-    command: poly
+  - name: poly shell
+    command: poly shell

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -18,6 +18,6 @@ tasks:
   - name: Polylith Real World nREPL Server
     command: clojure -Sdeps '{:deps {nrepl/nrepl {:mvn/version,"1.0.0"},cider/cider-nrepl {:mvn/version,"0.28.5"}}}' -M:dev:test:default -m nrepl.cmdline --middleware "[cider.nrepl/cider-middleware]"
   - name: Open Getting Started
-    command: code development/src/dev/getting_started.clj ; sleep 3; exit
+    command: code development/src/dev/getting_started.clj
   - name: Poly Tool
     command: poly

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -18,6 +18,6 @@ tasks:
   - name: Polylith Real World nREPL Server
     command: clojure -Sdeps '{:deps {nrepl/nrepl {:mvn/version,"1.0.0"},cider/cider-nrepl {:mvn/version,"0.28.5"}}}' -M:dev:test:default -m nrepl.cmdline --middleware "[cider.nrepl/cider-middleware]"
   - name: Open Getting Started
-    command: code development/src/dev/getting_started.clj ; exit
+    command: code development/src/dev/getting_started.clj ; sleep 3; exit
   - name: Poly Tool
     command: poly

--- a/deps.edn
+++ b/deps.edn
@@ -33,7 +33,7 @@
                     :extra-deps  {org.clojure/test.check {:mvn/version "1.1.1"}}}
 
              :poly {:main-opts  ["-m" "polylith.clj.core.poly-cli.core"]
-                    :extra-deps {polylith/clj-poly {:mvn/version "0.2.17-alpha"}}}
+                    :extra-deps {polylith/clj-poly {:mvn/version "0.2.18-SNAPSHOT"}}}
 
              :build {:deps {io.github.clojure/tools.build {:mvn/version "0.9.3"}
                             io.github.seancorfield/build-clj {:git/tag "v0.9.2"

--- a/development/src/dev/getting_started.clj
+++ b/development/src/dev/getting_started.clj
@@ -83,16 +83,20 @@
   :rcf)
 
 ;; ======== The poly tool ========
-;; Learn about the poly tool here: https://polylith.gitbook.io/poly/
 ;; We have started the tool in a terminal, open the terminal pane
-;; and you should find a terminal named “Poly tool”
-;; Commands you can try
-;; * `check` - checks the integrety of the project
+;; and you should find a terminal named “poly shell”
+;; Commands you can try from the poly shell:
+;; * `check` - checks the integrity of the project
 ;; * `help`
 ;; * `info`
 ;; * `help info`
 ;; * `test :all`
-;; * `help create
+;; * `help create`
+;;
+;; NB: Don't prepend your poly tool commands with `poly`, that's
+;; for when you run the `poly` command from the operating system
+;; shell (bash etcetera).
+;; Learn about the poly tool here: https://polylith.gitbook.io/poly/
 
 (comment
 


### PR DESCRIPTION
Renaming the Poly tool terminal to **poly shell**, and also using `poly shell` to start it, for added clarity. Updated the instructions accordingly + added a note about that the help texts are lying. Also incorporating @tengstrand's changes, so I think only this PR needs to be merged.

Closes #38 